### PR TITLE
update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:17.8.0
+FROM node:17.9.0
 RUN apt-get update -y
-RUN apt-get install -y zlib1g/stable-security subversion/stable-security openssl/stable-security ldap-utils/stable-security
+#RUN apt-get install -y zlib1g/stable-security subversion/stable-security openssl/stable-security ldap-utils/stable-security
 
 WORKDIR /app
 COPY package.json ./


### PR DESCRIPTION
plateng is still flagging CVE-2022-1292, probably because it's sitting in the base image despite the patch. This PR patches from the bottom of the stack.